### PR TITLE
Use JSON instead of Pickle

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,16 +297,17 @@ All of these classes can be imported from ``fwunit.ip``.
 Rules
 -----
 
-The output of the processing step is a pickled list of Rule objects.
+The output of the processing step is a JSON-formatted object.
+The `rules` key gives a list of rule objects, each of which has keys
 
-A Rule has `src` and `dst` attributes, IPSets consisting of the source and
-destination addresses to which it applies, and `app`, the name of the traffic
-type allowed.  It also has a `name` attribute indicating where it came from
-(e.g., the SRX policy name).
+ * `src` - a list of source IP ranges
+ * `dst` - a list of destination IP ranges
+ * `app` - the name of the permitted application
+ * `name` - the name of the rule
 
 The rules are normalized as follows (and this is what consumes most of the time in processing):
 
-  * For a given source and destination IP and application, exactly 0 or 1 rules
-    match; stated differently, there's no need to consider rules in order.
+ * For a given source and destination IP and application, exactly 0 or 1 rules
+   match; stated differently, there's no need to consider rules in order.
 
-  * If traffic matches a rule, it is permitted.  If no rule matches, it is denied.
+ * If traffic matches a rule, it is permitted.  If no rule matches, it is denied.

--- a/fwunit/combine/scripts.py
+++ b/fwunit/combine/scripts.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from . import process
-import cPickle as pickle
+from fwunit import types
+import json
 
 
 def run(cfg, fwunit_cfg):
@@ -12,8 +13,8 @@ def run(cfg, fwunit_cfg):
         if not isinstance(ip_space, list):
             ip_space = [ip_space]
         # look up and load the input's rules
-        pkl = fwunit_cfg[name]['output']
-        rules = pickle.load(open(pkl))
+        input = fwunit_cfg[name]['output']
+        rules = types.from_jsonable(json.load(open(input))['rules'])
         input_rules[name] = dict(rules=rules, ip_space=ip_space)
 
     return process.combine(input_rules)

--- a/fwunit/ip.py
+++ b/fwunit/ip.py
@@ -53,7 +53,6 @@ class IPSet(IPy.IPSet):
 
     # see https://github.com/haypo/python-ipy/pull/25
     def __contains__(self, ip):
-        assert 0
         valid_masks = self.prefixtable.keys()
         if isinstance(ip, IP):
             #Don't dig through more-specific ranges

--- a/fwunit/scripts.py
+++ b/fwunit/scripts.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import cPickle as pickle
 import argparse
 import logging
 import sys
@@ -11,7 +10,9 @@ import yaml
 import os
 import os.path
 from fwunit import log
+from fwunit import types
 import pkg_resources
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,8 @@ def main():
         logger.warning("running %s", source)
         rules = ep(src_cfg, cfg)
         logger.warning("writing resulting rules to %s", output)
-        pickle.dump(rules, open(output, "w"))
+        json.dump(dict(rules=types.to_jsonable(rules)),
+                  open(output, "w"))
 
 
 def query():

--- a/fwunit/tests.py
+++ b/fwunit/tests.py
@@ -2,10 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import cPickle as pickle
 import logging
+import json
 from fwunit.ip import IP, IPSet, IPPairs
 from nose.tools import ok_
+from fwunit import types
 from blessings import Terminal
 
 log = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ def _ipset(ip):
 
 class Rules(object):
     def __init__(self, filename):
-        self.rules = pickle.load(open(filename))
+        self.rules = types.from_jsonable(json.load(open(filename))['rules'])
 
     def assertDenies(self, src, dst, app):
         """Assert that no flow matching [src -> dst : app] is allowed"""

--- a/fwunit/types.py
+++ b/fwunit/types.py
@@ -4,11 +4,31 @@
 
 # special types that are used within the Pickle file
 
+from fwunit.ip import IPSet, IP
 from collections import namedtuple
 
-# A rule is a simple derivative of a policy:
-# - always 'permit'
-# - only one app
-# - specifies ipsets for source and destinations
-# - makes no reference to zones
 Rule = namedtuple('Rule', ['src', 'dst', 'app', 'name'])
+
+
+def ipset_to_jsonable(ipset):
+    return [str(pfx) for pfx in ipset]
+
+
+def to_jsonable(rules):
+    return [{'src': ipset_to_jsonable(r.src),
+             'dst': ipset_to_jsonable(r.dst),
+             'app': r.app,
+             'name': r.name}
+            for r in rules]
+
+
+def ipset_from_jsonable(ipset):
+    return IPSet([IP(pfx) for pfx in ipset])
+
+
+def from_jsonable(rules):
+    return [Rule(src=ipset_from_jsonable(r['src']),
+                 dst=ipset_from_jsonable(r['dst']),
+                 app=r['app'],
+                 name=r['name'])
+            for r in rules]


### PR DESCRIPTION
This just requires writing conversions for IP objects when writing out, and then converting back on reading in.  But it will make it a lot easier for other consumers in other languages to deal with the data
