### PR TITLE
Always handle rules as dicts keyed by app

### DIFF
--- a/fwunit/combine/process.py
+++ b/fwunit/combine/process.py
@@ -21,9 +21,7 @@ def combine(input_rules):
     all_apps = set()
     for name, info in input_rules.iteritems():
         ip_space = IPSet([IP(s) for s in info['ip_space']])
-        rules_by_app = {}
-        for r in info['rules']:
-            rules_by_app.setdefault(r.app, []).append(r)
+        rules_by_app = info['rules']
         all_apps = all_apps | set(rules_by_app)
         address_spaces.append(
             AddressSpace(rules=rules_by_app, ip_space=ip_space,
@@ -46,7 +44,7 @@ def combine(input_rules):
         address_spaces.append(
             AddressSpace(rules=rules, ip_space=unmanaged_space, name="unmanaged"))
 
-    combined_rules = []
+    combined_rules = {}
     for app in all_apps:
         logger.info("combining app %s", app)
         # The idea here is this: for each pair of address spaces, look at rules
@@ -76,7 +74,7 @@ def combine(input_rules):
                         combined_dst = local_dst & rr.dst
                         if not combined_dst:
                             continue
-                        combined_rules.append(Rule(
+                        combined_rules.setdefault(app, []).append(Rule(
                             src=combined_src,
                             dst=combined_dst,
                             app=app,

--- a/fwunit/combine/test_process.py
+++ b/fwunit/combine/test_process.py
@@ -25,10 +25,10 @@ def s(*ips):
 
 
 def test_one_address_space():
-    rules = [
+    rules = {'app': [
         Rule(s('1.2.3.4'), s('1.7.7.7'), 'app', 'p2p'),
         Rule(s('1.2.5.0/24'), s('1.7.7.7'), 'app', 'net'),
-    ]
+    ]}
     with no_simplify():
         result = process.combine(
             dict(nyc=dict(ip_space=['1.0.0.0/8'], rules=rules)))
@@ -36,23 +36,23 @@ def test_one_address_space():
 
 
 def test_nonoverlapping_rules():
-    nyc_rules = [
+    nyc_rules = {'app': [
         Rule(s('1.2.5.0/24'), s('2.2.5.0/24'), 'app', 'nyc'),
-    ]
-    dca_rules = [
+    ]}
+    dca_rules = {'app': [
         Rule(s('2.7.7.0/24'), s('1.7.7.0/24'), 'app', 'dca'),
-    ]
+    ]}
     with no_simplify():
         result = process.combine(
             dict(nyc=dict(ip_space=['1.0.0.0/8'], rules=nyc_rules),
                  dca=dict(ip_space=['2.0.0.0/8'], rules=dca_rules)))
-        eq_(result, [])
+        eq_(result, {})
 
 
 def test_identical_rules():
-    rules = [
+    rules = {'app': [
         Rule(s('2.7.7.0/24'), s('1.7.7.0/24'), 'app', 'nyc-dca'),
-    ]
+    ]}
     with no_simplify():
         result = process.combine(
             dict(nyc=dict(ip_space=['1.0.0.0/8'], rules=rules),
@@ -61,58 +61,58 @@ def test_identical_rules():
 
 
 def test_overlapping_rules():
-    nyc_rules = [
+    nyc_rules = {'app': [
         Rule(s('1.1.0.0/16'), s('2.0.0.0/8'), 'app', 'nyc'),
-    ]
-    dca_rules = [
+    ]}
+    dca_rules = {'app': [
         Rule(s('1.0.0.0/8'), s('2.1.0.0/16'), 'app', 'dca'),
-    ]
+    ]}
     with no_simplify():
         result = process.combine(
             dict(nyc=dict(ip_space=['1.0.0.0/8'], rules=nyc_rules),
                  dca=dict(ip_space=['2.0.0.0/8'], rules=dca_rules)))
-        eq_(result, [
+        eq_(result, {'app': [
             # takes the intersection of both rules:
             Rule(s('1.1.0.0/16'), s('2.1.0.0/16'), 'app', 'dca+nyc'),
-        ])
+        ]})
 
 
 def test_limited_by_space():
-    ord_rules = [
-    ]
-    nyc_rules = [
+    ord_rules = {'app': [
+    ]}
+    nyc_rules = {'app': [
         # /7 covers both ord and nyc
         Rule(s('0.0.0.0/7'), s('2.0.0.0/8'), 'app', 'nyc'),
-    ]
-    dca_rules = [
+    ]}
+    dca_rules = {'app': [
         Rule(s('0.0.0.0/7'), s('2.0.0.0/8'), 'app', 'dca'),
-    ]
+    ]}
     with no_simplify():
         result = process.combine(
             dict(ord=dict(ip_space=['0.0.0.0/8'], rules=ord_rules),
                  nyc=dict(ip_space=['1.0.0.0/8'], rules=nyc_rules),
                  dca=dict(ip_space=['2.0.0.0/8'], rules=dca_rules)))
-        eq_(sorted(result), sorted([
+        eq_(result, {'app': [
             # only nyc's address space is allowed
             Rule(s('1.0.0.0/8'), s('2.0.0.0/8'), 'app', 'dca+nyc'),
-        ]))
+        ]})
 
 
 def test_multiple_matches():
-    nyc_rules = [
+    nyc_rules = {'app': [
         Rule(s('1.1.1.1'), s('2.0.0.0/8'), 'app', 'one'),
         Rule(s('1.1.1.2'), s('2.0.0.0/8'), 'app', 'two'),
         Rule(s('1.1.1.3'), s('2.0.0.0/8'), 'app', 'three'),
-    ]
-    dca_rules = [
+    ]}
+    dca_rules = {'app': [
         Rule(s('1.0.0.0/8'), s('2.7.8.8'), 'app', 'eight'),
         Rule(s('1.0.0.0/8'), s('2.7.8.9'), 'app', 'nine'),
-    ]
+    ]}
     with no_simplify():
         result = process.combine(
             dict(nyc=dict(ip_space=['1.0.0.0/8'], rules=nyc_rules),
                  dca=dict(ip_space=['2.0.0.0/8'], rules=dca_rules)))
-        eq_(sorted(result), sorted([
+        eq_(sorted(result['app']), sorted([
             # takes the intersection of all rules:
             Rule(src=IPSet([IP('1.1.1.1')]), dst=IPSet([IP('2.7.8.8')]), app='app', name='eight+one'),
             Rule(src=IPSet([IP('1.1.1.1')]), dst=IPSet([IP('2.7.8.9')]), app='app', name='nine+one'),

--- a/fwunit/srx/process.py
+++ b/fwunit/srx/process.py
@@ -132,7 +132,7 @@ def process_address_sets_per_policy(zones, policies_by_zone_pair):
 
 def process_rules(app_map, policies, zone_nets, policies_by_zone_pair,
                   src_per_policy, dst_per_policy):
-    logger.info("processing rules by application")
+    logger.info("processing rules")
     # turn policies into a list of Rules (permit only), limited by zone,
     # that do not overlap.  The tricky bit here is processing policies in
     # order and accounting for denies.  We do this once for each
@@ -179,6 +179,5 @@ def process_rules(app_map, policies, zone_nets, policies_by_zone_pair,
                     break
         logger.debug(" from-zone %s to-zone %s => %d rules", from_zone, to_zone, rule_count)
 
-    # convert from by_app to just a list of rules (which include the app)
-    rules = simplify_rules(list(itertools.chain(*rules_by_app.itervalues())))
-    return rules
+    # simplify and return the result
+    return simplify_rules(rules_by_app)

--- a/fwunit/test_common.py
+++ b/fwunit/test_common.py
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from fwunit.ip import IP, IPSet
+from fwunit.types import Rule
+from nose.tools import eq_
+from fwunit.common import simplify_rules
+
+def _ipset(ip):
+    if isinstance(ip, basestring):
+        ip = IP(ip)
+    if isinstance(ip, IP):
+        ip = IPSet([ip])
+    return ip
+
+
+def r(src, dst, app='testapp', name='n'):
+    return Rule(src=_ipset(src), dst=_ipset(dst), app=app, name=name)
+
+
+def test_simplify_empty():
+    """Simplifying an empty set results in an empty set"""
+    eq_(simplify_rules({}), {})
+
+
+def test_simplify_no_combine():
+    """With no common sources or destinations, nothing changes"""
+    rules = {'testapp': [
+        r('10.0.0.0', '20.0.0.0'), 
+        r('20.0.0.0', '30.0.0.0'), 
+        r('30.0.0.0', '40.0.0.0'),
+    ]}
+    eq_(simplify_rules(rules), rules)
+
+
+def test_simplify_combine():
+    """Rules with the same source are combined"""
+    rules = {'testapp': [
+        r('10.0.0.0', '20.0.0.0'), 
+        r('20.0.0.0', '30.0.0.0'), 
+        r('10.0.0.0', '40.0.0.0'),
+    ]}
+    exp = {'testapp': [
+        r('10.0.0.0', IPSet([IP('20.0.0.0'), IP('40.0.0.0')])),
+        r('20.0.0.0', '30.0.0.0'), 
+    ]}
+    eq_(simplify_rules(rules), exp)
+
+
+def test_simplify_combine_iterations():
+    """A set of rules that requires a few passes to simplify is fully simplified"""
+    rules = {'testapp': [
+        r('10.0.0.0', IPSet([IP('20.0.0.0')])),
+        r('10.0.0.0', IPSet([IP('30.0.0.0')])),
+        r('11.0.0.0', IPSet([IP('20.0.0.0'), IP('30.0.0.0')])),
+        r('12.0.0.0', IPSet([IP('20.0.0.0'), IP('30.0.0.0')])),
+        r(IPSet([IP('10.0.0.0'), IP('11.0.0.0'), IP('12.0.0.0')]),
+          IPSet([IP('30.0.0.0'), IP('40.0.0.0')])),
+    ]}
+    exp = {'testapp': [
+        r(IPSet([IP('10.0.0.0'), IP('11.0.0.0'), IP('12.0.0.0')]),
+          IPSet([IP('20.0.0.0'), IP('30.0.0.0'), IP('40.0.0.0')])),
+    ]}
+    eq_(simplify_rules(rules), exp)

--- a/fwunit/types.py
+++ b/fwunit/types.py
@@ -6,6 +6,7 @@
 
 from fwunit.ip import IPSet, IP
 from collections import namedtuple
+import itertools
 
 Rule = namedtuple('Rule', ['src', 'dst', 'app', 'name'])
 
@@ -19,7 +20,7 @@ def to_jsonable(rules):
              'dst': ipset_to_jsonable(r.dst),
              'app': r.app,
              'name': r.name}
-            for r in rules]
+            for r in itertools.chain(*rules.itervalues())]
 
 
 def ipset_from_jsonable(ipset):
@@ -27,8 +28,12 @@ def ipset_from_jsonable(ipset):
 
 
 def from_jsonable(rules):
-    return [Rule(src=ipset_from_jsonable(r['src']),
-                 dst=ipset_from_jsonable(r['dst']),
-                 app=r['app'],
-                 name=r['name'])
-            for r in rules]
+    by_app = {}
+    for d in rules:
+        r = Rule(src=ipset_from_jsonable(d['src']),
+                 dst=ipset_from_jsonable(d['dst']),
+                 app=d['app'],
+                 name=d['name'])
+        app = r.app
+        by_app.setdefault(app, []).append(r)
+    return by_app


### PR DESCRIPTION
In most cases, this is the useful form.  And in particular for tests
that address only one app (the most common kind), this allows much
quicker access to the relevant rules.
