### PR TITLE
Handle `any-ipv4` address as `any`

### DIFF
--- a/fwunit/srx/parse.py
+++ b/fwunit/srx/parse.py
@@ -129,6 +129,7 @@ class Zone(object):
         #: name -> ipset, based on the zone's address book
         self.addresses = {
             'any': IPSet([IP('0.0.0.0/0')]),
+            'any-ipv4': IPSet([IP('0.0.0.0/0')]),
             # fwunit doesn't handle ipv6, so this is an empty set
             'any-ipv6': IPSet([]),
         }

--- a/fwunit/test/integration/test_srx.py
+++ b/fwunit/test/integration/test_srx.py
@@ -28,7 +28,8 @@ policies = {
     ('untrust', 'trust'): [
         dict(sequence=1, name='no-shadow-ping', src='any', dst='shadow', app='ping', action='deny'),
         dict(sequence=2, name='ping', src='any', dst='dmz', app='ping', action='permit'),
-        dict(sequence=2, name='admin', src='puppet', dst='trustedhost', app='ssh', action='permit'),
+        dict(sequence=3, name='admin', src='puppet', dst='trustedhost', app='ssh', action='permit'),
+        dict(sequence=4, name='admin', src='any-ipv6', dst='trustedhost', app='ssh', action='permit'),
         dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'),
     ],
     ('untrust', 'untrust'): [

--- a/fwunit/test/unit/test_srx_parse.py
+++ b/fwunit/test/unit/test_srx_parse.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import xml.etree.ElementTree as ET
-from fwunit.ip import IP
+from fwunit.ip import IP, IPSet
 from fwunit.srx import parse
 from nose.tools import eq_
 from fwunit.test.util.srx_xml import route_xml_11_4R6
@@ -23,14 +23,17 @@ def test_parse_zones():
     z = parse.Zone._from_xml(elt)
     eq_(z.interfaces, ['reth0'])
     eq_(sorted(z.addresses.keys()),
-        sorted(['any', 'any-ipv6', 'host1', 'host2', 'hosts', 'puppet']))
+        sorted(['any', 'any-ipv4', 'any-ipv6', 'host1', 'host2', 'hosts', 'puppet']))
+    eq_(z.addresses['any'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv4'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv6'], IPSet([]))
 
 
 def test_parse_zones_empty():
     elt = parse_xml(zones_empty_xml, './/security-zone')
     z = parse.Zone._from_xml(elt)
     eq_(z.interfaces, [])
-    eq_(sorted(z.addresses.keys()), sorted(['any', 'any-ipv6']))
+    eq_(sorted(z.addresses.keys()), sorted(['any', 'any-ipv6', 'any-ipv4']))
 
 
 def test_parse_route_11_4R6():


### PR DESCRIPTION
```
ERROR OUTPUT:
Traceback (most recent call last):
  File "/opt/fwunit/releng/bin/fwunit", line 9, in <module>
    load_entry_point('fwunit==0.1.0', 'console_scripts', 'fwunit')()
  File "/opt/fwunit/releng/src/fwunit/fwunit/scripts.py", line 87, in main
    rules = ep(src_cfg, cfg)
  File "/opt/fwunit/releng/src/fwunit/fwunit/srx/scripts.py", line 16, in run
    return policies_to_rules(app_map, firewall)
  File "/opt/fwunit/releng/src/fwunit/fwunit/srx/process.py", line 24, in policies_to_rules
    firewall.zones, policies_by_zone_pair)
  File "/opt/fwunit/releng/src/fwunit/fwunit/srx/process.py", line 127, in process_address_sets_per_policy
    (get_from(a) for a in pol.source_addresses), IPSet())
  File "/opt/fwunit/releng/src/fwunit/fwunit/srx/process.py", line 127, in <genexpr>
    (get_from(a) for a in pol.source_addresses), IPSet())
  File "/opt/fwunit/releng/src/fwunit/fwunit/srx/process.py", line 122, in <lambda>
    get_from = lambda a: a if isinstance(a, IPSet) else from_addrbook[a]
KeyError: 'any-ipv4'
```
