### PR TITLE
Add a '--quiet' option to fwunit

### DIFF
--- a/fwunit/log.py
+++ b/fwunit/log.py
@@ -35,5 +35,5 @@ def setup(verbose):
     root_logger = logging.getLogger()
     clihandler = logging.StreamHandler(sys.stdout)
     clihandler.setFormatter(clifmt)
-    root_logger.setLevel(logging.NOTSET)
+    root_logger.setLevel(logging.NOTSET if verbose else logging.WARNING)
     root_logger.addHandler(clihandler)


### PR DESCRIPTION
The fwunit crontask emits a _massive_ amount of info-level logging, all of which is basically progress data.  `--quiet` should limit to WARNING and above.
