### PR TITLE
Make rule loading more efficient

### DIFF
--- a/docs/implementation.rst
+++ b/docs/implementation.rst
@@ -28,3 +28,79 @@ The rules are normalized as follows (and this is what consumes most of the time 
  * If traffic matches a rule, it is permitted.  If no rule matches, it is denied.
 
  * Policies allowing any application are represented by explicit rules for each known application, with the addition of rules with application '@@other' to represent the unknown applications.
+
+
+Loading Source Objects
+----------------------
+
+Rule sets are embedded in :py:class:`~fwunit.analysis.sources.Source` objects, which provide a set of useful methods for analysis.
+In a testing environment, rule sets are loaded via :py:class:`~fwunit.analysis.testcontext.TestContext`; this section describes access to rules within fwunit itself.
+
+To get a source object, you will first need a config, which can be retrieved from :py:func:`~fwunit.analysis.config.load_config`:
+
+.. py:function:: fwunit.analysis.config.load_config(filename="fwunit.yaml")
+
+    :param filename: the configuration filename to load
+    :returns: a config object
+
+    Load a configuration file.
+    As a side-effect, this function chdir's to the configuration directory.
+
+    The function operates on the assumption that a single process will only ever reference one configuration, and thus caches the configuration after the first call.
+    Subsequent calls with the same filename will return the same object.
+    Subsequent calls with a different filename will raise an exception.
+
+With the config object in hand, call :py:func:`~fwunit.analysis.sources.load_source`:
+
+.. py:function:: fwunit.analysis.sources.load_source(config, source)
+
+    :param config: a config object
+    :param source: the name of the source to load
+    :returns: a source object
+    :rtype: :py:class:`~fwunit.analysis.sources.Source`
+
+    Load the ruleset for the given source.
+    Rulesets are cached globally to the process.
+
+Using Source Objects
+--------------------
+
+.. py:class:: fwunit.analysis.sources.Source
+
+    The data from a particular source in ``fwunit.yaml``, along with some analysis methods.
+
+    .. py:method:: rulesDeny(src, dst, apps)
+
+        :param src: source IPs
+        :param dst: destination IPs
+        :param apps: application names
+        :type apps: list or string
+
+        Returns True if the rules deny all traffic from *src* to *dst* via all given *apps*; otherwise False.
+
+    .. py:method:: rulesPermit(src, dst, apps)
+
+        :param src: source IPs
+        :param dst: destination IPs
+        :param apps: application names
+        :type apps: list or string
+
+        Returns True if the rules allow all traffic from *src* to *dst* via all given *apps*; otherwise False.
+
+    Note that ``rulesdeny(..)`` is not the same as ``not rulesPermit(..)``: if some -- but not all -- traffic is permitted from *src* to *dst*, then both methods will return False.
+
+    .. py:method:: allApps(src, dst, debug=False)
+
+        :param src: source IPs
+        :param dst: destination IPs
+        :param debug: if True, log the full list of matching flows
+        
+        See :py:meth:`~fwunit.analysis.testcontext.TestContext.allApps`.
+
+    .. py:method:: sourcesFor(dst, app, ignore_sources=None)
+
+        :param dst: destination IPs
+        :param app: application
+        :param ignore_sources: source IPs to ignore
+
+        See :py:meth:`~fwunit.analysis.testcontext.TestContext.sourcesFor`.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -16,7 +16,7 @@ The following might be in a file named `test_puppet.py`.
     from fwunit import TestContext
     from fwunit.ip import IP, IPSet
 
-    rules = TestContext('my-network')
+    tc = TestContext('my-network')
 
     # hosts
 
@@ -37,17 +37,17 @@ The following might be in a file named `test_puppet.py`.
     def test_puppetmaster_access():
         """The entire internal_network can access the puppet masters."""
         for app in 'puppet', 'http', 'https':
-            fw1.assertPermits(internal_network, puppetmasters, app)
+            tc.assertPermits(internal_network, puppetmasters, app)
 
     def test_puppetmaster_no_other_apps():
         """Access to puppetmasters is limited to puppet, http, and https"""
-        fw1.assertAllApps(IPSet([IP('0.0.0.0/0')]), puppetmasters,
+        tc.assertAllApps(IPSet([IP('0.0.0.0/0')]), puppetmasters,
                           ['puppet', 'http', 'https'])
 
     def test_puppetmaster_limited():
         """The exteernal networks cannot access the puppet masters."""
         for app in 'puppet', 'http', 'https':
-            fw1.assertDenies(external_network, puppetmasters, app)
+            tc.assertDenies(external_network, puppetmasters, app)
 
 Running this test is as simple as
 
@@ -65,7 +65,7 @@ It's safe to do this individually in each test script, as the results are cached
 
     from fwunit import TestContext
 
-    rules = TestContext('source-name')
+    tc = TestContext('source-name')
 
 The :py:class:`~fwunit.analysis.testcontext.TestContext` class uses ``fwunit.yaml`` in the current directory to look up the proper source file for the given source name.
 
@@ -102,7 +102,7 @@ Once you have the rules loaded, you can start writing test methods::
 
     def test_puppetmaster_access():
         for app in 'puppet', 'http', 'https':
-            fw1.assertPermits(internal_network, puppetmasters, app)
+            tc.assertPermits(internal_network, puppetmasters, app)
 
 Utility Methods
 ---------------

--- a/fwunit/analysis/config.py
+++ b/fwunit/analysis/config.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import yaml
+
+_loaded_config = None
+
+def load_config(filename="fwunit.yaml"):
+    """Load the config, which is stored persistently for the duration of the
+    process.  As a side-effect, this chdir's to the configuration directory.
+    This function can be called multiple times with the same configuration
+    filename."""
+    global _loaded_config
+    if _loaded_config:
+        if _loaded_config[0] != filename:
+            raise RuntimeError("load_config already called with %r" % (_loaded_config[0],))
+        return
+
+    # chdir to cfg file so rel paths work
+    config_dir = os.path.dirname(os.path.abspath(filename))
+    os.chdir(config_dir)
+
+    _loaded_config = (filename, yaml.load(open(filename)))
+    return _loaded_config[1]

--- a/fwunit/analysis/config.py
+++ b/fwunit/analysis/config.py
@@ -8,10 +8,6 @@ import yaml
 _loaded_config = None
 
 def load_config(filename="fwunit.yaml"):
-    """Load the config, which is stored persistently for the duration of the
-    process.  As a side-effect, this chdir's to the configuration directory.
-    This function can be called multiple times with the same configuration
-    filename."""
     global _loaded_config
     if _loaded_config:
         if _loaded_config[0] != filename:

--- a/fwunit/analysis/config.py
+++ b/fwunit/analysis/config.py
@@ -20,3 +20,9 @@ def load_config(filename="fwunit.yaml"):
 
     _loaded_config = (filename, yaml.load(open(filename)))
     return _loaded_config[1]
+
+
+def _clear():
+    # for tests only
+    global _loaded_config
+    _loaded_config = None

--- a/fwunit/analysis/sources.py
+++ b/fwunit/analysis/sources.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+
+from fwunit import types
+
+_cache = {}
+
+class Source(object):
+    """The data from a particular source in fwunit.yaml"""
+
+    def __init__(self, filename):
+        self.rules = types.from_jsonable(json.load(open(filename))['rules'])
+
+def load_source(cfg, source):
+    """Load the named source.  Sources are cached, so multiple calls with the same name
+    will not repeatedly re-load the data from disk."""
+    if source not in _cache:
+        _cache[source] = Source(cfg[source]['output'])
+    return _cache[source]

--- a/fwunit/analysis/sources.py
+++ b/fwunit/analysis/sources.py
@@ -21,10 +21,6 @@ def _ipset(ip):
     return ip
 
 class Source(object):
-    """The data from a particular source in fwunit.yaml, along with some analysis methods."""
-
-    # TODO: document these changes
-
     def __init__(self, filename):
         self.rules = types.from_jsonable(json.load(open(filename))['rules'])
 

--- a/fwunit/analysis/sources.py
+++ b/fwunit/analysis/sources.py
@@ -2,17 +2,128 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import itertools
 import json
+import logging
 
+from blessings import Terminal
 from fwunit import types
+from fwunit.ip import IP, IPSet, IPPairs
 
-_cache = {}
+log = logging.getLogger(__name__)
+terminal = Terminal()
+
+def _ipset(ip):
+    if isinstance(ip, basestring):
+        ip = IP(ip)
+    if isinstance(ip, IP):
+        ip = IPSet([ip])
+    return ip
 
 class Source(object):
-    """The data from a particular source in fwunit.yaml"""
+    """The data from a particular source in fwunit.yaml, along with some analysis methods."""
+
+    # TODO: refactor queries to use these
+    # TODO: document these changes
 
     def __init__(self, filename):
         self.rules = types.from_jsonable(json.load(open(filename))['rules'])
+
+    def _rules_for_app(self, app):
+        # get the rules for the given app, or if no such app is known, for @@other
+        try:
+            return self.rules[app]
+        except KeyError:
+            return self.rules.get('@@other', [])
+
+    def rulesDeny(self, src, dst, apps):
+        src = _ipset(src)
+        dst = _ipset(dst)
+        log.info("rulesDeny(%r, %r, %r)" % (src, dst, apps))
+        failures = 0
+        apps = apps if not isinstance(apps, basestring) else [apps]
+        for app in apps:
+            log.info("checking application %r" % app)
+            for rule in self._rules_for_app(app):
+                src_matches = (rule.src & src)
+                if not src_matches:
+                    continue
+                dst_matches = (rule.dst & dst)
+                if not dst_matches:
+                    continue
+                log.error("policy {t.cyan}{name}{t.normal} permits {t.bold_cyan}{app}{t.normal} "
+                        "traffic\n{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
+                    t=terminal,
+                    name=rule.name,
+                    app=app,
+                    src=src_matches,
+                    dst=dst_matches)
+                    )
+                failures += 1
+        return failures == 0
+
+    def rulesPermit(self, src, dst, apps):
+        src = _ipset(src)
+        dst = _ipset(dst)
+        log.info("rulesPermit(%r, %r, %r)" % (src, dst, apps))
+        remaining = IPPairs((src, dst))
+        apps = apps if not isinstance(apps, basestring) else [apps]
+        for app in apps:
+            log.info("checking application %r" % app)
+            for rule in self._rules_for_app(app):
+                if (rule.src & src) and (rule.dst & dst):
+                    log.info("matched policy {t.cyan}{name}{t.normal}\n{t.yellow}{src}{t.normal} "
+                            "-> {t.magenta}{dst}{t.normal}".format(
+                        t=terminal, name=rule.name, src=rule.src, dst=rule.dst))
+                    remaining = remaining - IPPairs((rule.src, rule.dst))
+        if remaining:
+            flows = ",\n".join("{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
+                                t=terminal, src=p[0], dst=p[1]) for p in remaining)
+            log.error("No rule found for flows, app {t.bold_cyan}{app}{t.normal}\n{flows}"
+                                 .format(t=terminal, app=app, flows=flows))
+            return False
+        return True
+
+    def allApps(self, src, dst, debug=False):
+        src = _ipset(src)
+        dst = _ipset(dst)
+        log.info("allApps(%r, %r)" % (src, dst))
+        rv = set()
+        for rule in itertools.chain(*self.rules.itervalues()):
+            if not debug and rule.app in rv:
+                continue
+            src_matches = (rule.src & src)
+            if not src_matches:
+                continue
+            dst_matches = (rule.dst & dst)
+            if not dst_matches:
+                continue
+            log.info("matched policy {t.cyan}{name}{t.normal} app {t.bold_cyan}{app}{t.normal}\n"
+                     "{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
+                        t=terminal, name=rule.name, src=src_matches, dst=dst_matches, app=rule.app))
+            rv.add(rule.app)
+        if '@@other' in rv:
+            rv = set(['any'])
+        return rv
+
+    def sourcesFor(self, dst, app, ignore_sources=None):
+        dst = _ipset(dst)
+        log.info("sourcesFor(%r, %r, ignore_sources=%r)" % (dst, app, ignore_sources))
+        rv = IPSet()
+        for rule in self._rules_for_app(app):
+            if rule.dst & dst:
+                src = rule.src
+                if ignore_sources:
+                    src = src - ignore_sources
+                if src:
+                    log.info("matched policy {t.cyan}{name}{t.normal}\n{t.yellow}{src}{t.normal} "
+                             "-> {t.magenta}{dst}{t.normal}".format(
+                                t=terminal, name=rule.name, src=src, dst=rule.dst & dst))
+                    rv = rv + src
+        return rv
+
+_cache = {}
+
 
 def load_source(cfg, source):
     """Load the named source.  Sources are cached, so multiple calls with the same name

--- a/fwunit/analysis/sources.py
+++ b/fwunit/analysis/sources.py
@@ -126,3 +126,9 @@ def load_source(cfg, source):
     if source not in _cache:
         _cache[source] = Source(cfg[source]['output'])
     return _cache[source]
+
+
+def _clear():
+    # for tests only
+    global _cache
+    _cache = {}

--- a/fwunit/analysis/sources.py
+++ b/fwunit/analysis/sources.py
@@ -23,7 +23,6 @@ def _ipset(ip):
 class Source(object):
     """The data from a particular source in fwunit.yaml, along with some analysis methods."""
 
-    # TODO: refactor queries to use these
     # TODO: document these changes
 
     def __init__(self, filename):

--- a/fwunit/analysis/testcontext.py
+++ b/fwunit/analysis/testcontext.py
@@ -3,13 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
-import json
-import yaml
 import os
 import itertools
 from fwunit.ip import IP, IPSet, IPPairs
 from nose.tools import ok_
-from fwunit import types
+from fwunit.analysis import config
+from fwunit.analysis import sources
 from blessings import Terminal
 
 log = logging.getLogger(__name__)
@@ -26,9 +25,9 @@ class TestContext(object):
     def __init__(self, source):
         if not os.path.exists('fwunit.yaml'):
             raise RuntimeError('Tests must be run from the directory containing `fwunit.yaml`')
-        cfg = yaml.load(open('fwunit.yaml'))
-        src_cfg = cfg[source]
-        self.rules = types.from_jsonable(json.load(open(src_cfg['output']))['rules'])
+        cfg = config.load_config('fwunit.yaml')
+        self.source = sources.load_source(cfg, source)
+        self.rules = self.source.rules
 
     def _rules_for_app(self, app):
         # get the rules for the given app, or if no such app is known, for @@other

--- a/fwunit/analysis/testcontext.py
+++ b/fwunit/analysis/testcontext.py
@@ -4,8 +4,6 @@
 
 import logging
 import os
-import itertools
-from fwunit.ip import IP, IPSet, IPPairs
 from nose.tools import ok_
 from fwunit.analysis import config
 from fwunit.analysis import sources
@@ -14,124 +12,26 @@ from blessings import Terminal
 log = logging.getLogger(__name__)
 terminal = Terminal()
 
-def _ipset(ip):
-    if isinstance(ip, basestring):
-        ip = IP(ip)
-    if isinstance(ip, IP):
-        ip = IPSet([ip])
-    return ip
-
 class TestContext(object):
     def __init__(self, source):
         if not os.path.exists('fwunit.yaml'):
             raise RuntimeError('Tests must be run from the directory containing `fwunit.yaml`')
         cfg = config.load_config('fwunit.yaml')
         self.source = sources.load_source(cfg, source)
-        self.rules = self.source.rules
-
-    def _rules_for_app(self, app):
-        # get the rules for the given app, or if no such app is known, for @@other
-        try:
-            return self.rules[app]
-        except KeyError:
-            return self.rules.get('@@other', [])
 
     def assertDenies(self, src, dst, apps):
-        src = _ipset(src)
-        dst = _ipset(dst)
-        log.info("assertDenies(%r, %r, %r)" % (src, dst, apps))
-        failures = 0
-        apps = apps if not isinstance(apps, basestring) else [apps]
-        for app in apps:
-            log.info("checking application %r" % app)
-            for rule in self._rules_for_app(app):
-                src_matches = (rule.src & src)
-                if not src_matches:
-                    continue
-                dst_matches = (rule.dst & dst)
-                if not dst_matches:
-                    continue
-                log.error("policy {t.cyan}{name}{t.normal} permits {t.bold_cyan}{app}{t.normal} "
-                        "traffic\n{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
-                    t=terminal,
-                    name=rule.name,
-                    app=app,
-                    src=src_matches,
-                    dst=dst_matches)
-                    )
-                failures += 1
-        ok_(failures == 0, "%d matching rules" % failures)
+        ok_(self.source.rulesDeny(src, dst, apps))
 
     def assertPermits(self, src, dst, apps):
-        src = _ipset(src)
-        dst = _ipset(dst)
-        log.info("assertPermits(%r, %r, %r)" % (src, dst, apps))
-        remaining = IPPairs((src, dst))
-        apps = apps if not isinstance(apps, basestring) else [apps]
-        for app in apps:
-            log.info("checking application %r" % app)
-            for rule in self._rules_for_app(app):
-                if (rule.src & src) and (rule.dst & dst):
-                    log.info("matched policy {t.cyan}{name}{t.normal}\n{t.yellow}{src}{t.normal} "
-                            "-> {t.magenta}{dst}{t.normal}".format(
-                        t=terminal, name=rule.name, src=rule.src, dst=rule.dst))
-                    remaining = remaining - IPPairs((rule.src, rule.dst))
-        if remaining:
-            flows = ",\n".join("{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
-                                t=terminal, src=p[0], dst=p[1]) for p in remaining)
-            raise AssertionError("No rule found for flows, app {t.bold_cyan}{app}{t.normal}\n{flows}"
-                                 .format(t=terminal, app=app, flows=flows))
+        ok_(self.source.rulesPermit(src, dst, apps))
 
     def sourcesFor(self, dst, app, ignore_sources=None):
-        dst = _ipset(dst)
-        log.info("sourcesFor(%r, %r, ignore_sources=%r)" % (dst, app, ignore_sources))
-        rv = IPSet()
-        for rule in self._rules_for_app(app):
-            if rule.dst & dst:
-                src = rule.src
-                if ignore_sources:
-                    src = src - ignore_sources
-                if src:
-                    log.info("matched policy {t.cyan}{name}{t.normal}\n{t.yellow}{src}{t.normal} "
-                             "-> {t.magenta}{dst}{t.normal}".format(
-                                t=terminal, name=rule.name, src=src, dst=rule.dst & dst))
-                    rv = rv + src
-        return rv
+        return self.source.sourcesFor(dst, app, ignore_sources=ignore_sources)
 
     def allApps(self, src, dst, debug=False):
-        src = _ipset(src)
-        dst = _ipset(dst)
-        log.info("appsTo(%r, %r)" % (src, dst))
-        rv = set()
-        for rule in itertools.chain(*self.rules.itervalues()):
-            if not debug and rule.app in rv:
-                continue
-            src_matches = (rule.src & src)
-            if not src_matches:
-                continue
-            dst_matches = (rule.dst & dst)
-            if not dst_matches:
-                continue
-            log.info("matched policy {t.cyan}{name}{t.normal} app {t.bold_cyan}{app}{t.normal}\n"
-                     "{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
-                        t=terminal, name=rule.name, src=src_matches, dst=dst_matches, app=rule.app))
-            rv.add(rule.app)
-        if '@@other' in rv:
-            rv = set(['any'])
-        return rv
+        return self.source.allApps(src, dst, debug=debug)
 
     def assertAllApps(self, src, dst, apps, debug=False):
-        src = _ipset(src)
-        dst = _ipset(dst)
-        log.info("appsOn(%r, %r, %r)" % (src, dst, apps))
-        found_apps = set()
-        for rule in itertools.chain(*self.rules.itervalues()):
-            if not debug and rule.app in found_apps:
-                continue
-            if rule.dst & dst and rule.src & src:
-                log.info("matched policy {t.cyan}{name}{t.normal} app {t.bold_cyan}{app}{t.normal}\n"
-                            "{t.yellow}{src}{t.normal} -> {t.magenta}{dst}{t.normal}".format(
-                            t=terminal, name=rule.name, src=src, dst=rule.dst & dst, app=rule.app))
-                found_apps.add(rule.app)
+        found_apps = self.source.allApps(src, dst, debug=debug)
         if found_apps != set(apps):
             raise AssertionError("got apps %r; expected %r" % (sorted(list(found_apps)), sorted(list(apps))))

--- a/fwunit/query/apps.py
+++ b/fwunit/query/apps.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from .. import tests
+from fwunit.analysis import sources
 from . import base
 
 class AppsQuery(base.Query):
@@ -23,6 +23,6 @@ class AppsQuery(base.Query):
         super(AppsQuery, self).__init__(subparser)
 
     def run(self, args, cfg):
-        rules = tests.Rules(args.source)
-        for app in sorted(rules.allApps(args.src_ip, args.dst_ip)):
+        src = sources.load_source(cfg, args.source)
+        for app in sorted(src.allApps(args.src_ip, args.dst_ip)):
             print app

--- a/fwunit/query/denied.py
+++ b/fwunit/query/denied.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import sys
-from .. import tests
 from . import base
+from fwunit.analysis import sources
 from blessings import Terminal
 
 class DeniedQuery(base.Query):
@@ -30,14 +30,12 @@ class DeniedQuery(base.Query):
 
     def run(self, args, cfg):
         terminal = Terminal()
-        rules = tests.Rules(args.source)
-        try:
-            rules.assertDenies(args.src_ip, args.dst_ip, args.app)
-        except AssertionError:
+        src = sources.load_source(cfg, args.source)
+        if src.rulesDeny(args.src_ip, args.dst_ip, args.app):
+            if not args.quiet:
+                print terminal.black_on_green("Flow denied")
+        else:
             if not args.quiet:
                 print terminal.black_on_red("Flow not denied")
             sys.exit(1)
-        else:
-            if not args.quiet:
-                print terminal.black_on_green("Flow denied")
 

--- a/fwunit/query/permitted.py
+++ b/fwunit/query/permitted.py
@@ -3,8 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import sys
-from .. import tests
 from . import base
+from fwunit.analysis import sources
 from blessings import Terminal
 
 class PermittedQuery(base.Query):
@@ -30,13 +30,11 @@ class PermittedQuery(base.Query):
 
     def run(self, args, cfg):
         terminal = Terminal()
-        rules = tests.Rules(args.source)
-        try:
-            rules.assertPermits(args.src_ip, args.dst_ip, args.app)
-        except AssertionError:
+        src = sources.load_source(cfg, args.source)
+        if src.rulesPermit(args.src_ip, args.dst_ip, args.app):
+            if not args.quiet:
+                print terminal.black_on_green("Flow permitted")
+        else:
             if not args.quiet:
                 print terminal.black_on_red("Flow not permitted")
             sys.exit(1)
-        else:
-            if not args.quiet:
-                print terminal.black_on_green("Flow permitted")

--- a/fwunit/scripts.py
+++ b/fwunit/scripts.py
@@ -6,11 +6,11 @@ import argparse
 import logging
 import sys
 import textwrap
-import yaml
 import os
 import os.path
 from fwunit import log
 from fwunit import types
+from fwunit.analysis import config
 import pkg_resources
 import json
 
@@ -20,12 +20,7 @@ logger = logging.getLogger(__name__)
 def _setup(parser):
     args = parser.parse_args(sys.argv[1:])
     log.setup(args.verbose)
-    cfg = yaml.load(open(args.config_file))
-
-    # chdir to cfg file so rel paths work
-    config_dir = os.path.dirname(os.path.abspath(args.config_file))
-    os.chdir(config_dir)
-
+    cfg = config.load_config(args.config_file)
     return args, cfg
 
 def main():

--- a/fwunit/test/integration/test_comprehensive.py
+++ b/fwunit/test/integration/test_comprehensive.py
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os
+import shutil
+import sys
+import yaml
+
+from fwunit import TestContext
+from fwunit import types
+from fwunit import scripts
+from fwunit.test.util import ipset
+
+FWUNIT_YAML = {
+    'rules': {
+        'type': 'anything',
+        'output': 'rules.json',
+    }
+}
+RULES = {
+    'http': [
+        # within this ip space
+        types.Rule(src=ipset('10.10.0.0/16'), dst=ipset('10.20.0.0/16'), app='http', name='10->10'),
+        # from and to "unmanaged" space
+        types.Rule(src=ipset('30.10.0.0/16'), dst=ipset('10.20.0.0/16'), app='http', name='30->10'),
+        types.Rule(src=ipset('10.10.0.0/16'), dst=ipset('30.20.0.0/16'), app='http', name='10->30'),
+        # from and to the 20/8 space
+        types.Rule(src=ipset('20.20.0.0/16', '20.30.0.0/16'),
+                   dst=ipset('10.20.0.0/16', '10.30.0.0/16'),
+                   app='http', name='20->10'),
+        types.Rule(src=ipset('10.10.0.0/16', '10.20.0.0/16'),
+                   dst=ipset('20.10.0.0/16', '20.20.0.0/16'),
+                   app='http', name='10->20'),
+    ],
+}
+
+old_sys_argv = None
+old_cwd = None
+
+def setup():
+    global old_sys_argv, old_cwd
+    old_sys_argv = sys.argv[:]
+    old_cwd = os.getcwd()
+
+    if os.path.exists('test_dir'):
+        shutil.rmtree('test_dir')
+    os.makedirs('test_dir')
+    os.chdir('test_dir')
+    yaml.dump(FWUNIT_YAML,
+              open('fwunit.yaml', "w"))
+    json.dump(dict(rules=types.to_jsonable(RULES)),
+              open('rules.json', "w"))
+
+
+def teardown():
+    os.chdir(old_cwd)
+    sys.argv = old_sys_argv
+
+    if os.path.exists('test_dir'):
+        shutil.rmtree('test_dir')
+
+# run each of the queries once, just to see that the command-line processing,
+# rule loading, and analysis connect properly
+
+def test_permitted():
+    sys.argv = ['fwunit', 'permitted', 'rules', '10.10.10.1', '10.20.1.1', 'http']
+    scripts.query()
+
+
+def test_denied():
+    sys.argv = ['fwunit', 'denied', 'rules', '10.10.10.1', '99.20.1.1', 'http']
+    scripts.query()
+
+
+def test_apps():
+    sys.argv = ['fwunit', 'apps', 'rules', '10.10.10.1', '99.20.1.1']
+    scripts.query()
+
+# load rules as a test script would
+
+def test_test():
+    tc = TestContext('rules')
+    tc.assertPermits('10.10.10.1', '10.20.1.1', 'http')

--- a/fwunit/test/unit/test_analysis_testcontext.py
+++ b/fwunit/test/unit/test_analysis_testcontext.py
@@ -8,6 +8,8 @@ import yaml
 import json
 import os
 from fwunit.test.util import ipset
+from fwunit.analysis import config
+from fwunit.analysis import sources
 from fwunit.analysis.testcontext import TestContext
 from fwunit.test.util.test_rules import TEST_RULES
 from fwunit import types
@@ -18,6 +20,8 @@ old_cwd = None
 rules = None
 
 def setup_module():
+    config._clear()
+    sources._clear()
     global dir, old_cwd, rules
     dir = tempfile.mkdtemp()
     old_cwd = os.getcwd()


### PR DESCRIPTION
Parsing the JSON in a rules file, even for the full set of releng rules, is pretty quick. However, the `fwunit.types.from_jsonable` process takes several seconds.  Some profiling can probably help make either that code or IPy more efficient in time or space.

For example: consider caching `IP` instances if there are enough duplicates.