### PR TITLE
Support global policies and zones

### DIFF
--- a/fwunit/test/integration/test_srx.py
+++ b/fwunit/test/integration/test_srx.py
@@ -4,73 +4,66 @@
 
 from fwunit.srx import scripts
 from nose.tools import eq_
-import mock
 from fwunit.ip import IP, IPSet
 from fwunit.types import Rule
-from fwunit.test.util.srx_xml import route_xml
-from fwunit.test.util.srx_xml import zones_xml
-from fwunit.test.util.srx_xml import policy_xml
-from fwunit.test.util.srx_xml import policy_tpl
-from fwunit.srx import show
+from fwunit.test.util.srx_xml import FakeSRX
 
-# set up to produce fake XML output from the firewall
-
-policies = {
-    ('trust', 'trust'): [
-        dict(sequence=1, name='ssh--any', src='any', dst='any', app='junos-ssh', action='permit'),
-        dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'),
-    ],
-    ('trust', 'untrust'): [
-        dict(sequence=1, name='ssh-untrust', src='any', dst='any', app='junos-ssh', action='permit'),
-        dict(sequence=2, name='puppet', src='any', dst='puppet', app='puppet', action='permit'),
-        dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'),
-    ],
-    ('untrust', 'trust'): [
-        dict(sequence=1, name='no-shadow-ping', src='any', dst='shadow', app='junos-ping', action='deny'),
-        dict(sequence=2, name='ping', src='any', dst='dmz', app='junos-ping', action='permit'),
-        dict(sequence=3, name='admin', src='puppet', dst='trustedhost', app='junos-ssh', action='permit'),
-        dict(sequence=4, name='admin', src='any-ipv6', dst='trustedhost', app='junos-ssh', action='permit'),
-        dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'),
-    ],
-    ('untrust', 'untrust'): [
-        dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'),
-    ],
-}
-
-def fake_show(request):
-    if request == 'route':
-        return route_xml
-    elif request == 'configuration security zones':
-        return zones_xml
-    elif request.startswith('security policies'):
-        request = request.split()
-        from_zone, to_zone = request[3], request[5]
-        policy_dicts = policies[from_zone, to_zone]
-        policy_xmls = [policy_tpl % d for d in policy_dicts]
-        return policy_xml % dict(from_zone=from_zone, to_zone=to_zone,
-                                 policies='\n'.join(policy_xmls))
-    else:
-        raise AssertionError("bad request")
-
-conn_patch = mock.patch('fwunit.srx.show.Connection', spec=show.Connection)
+F = None
 
 
 def setup_module():
-    m = conn_patch.start()
-    m().show.side_effect = fake_show
+    global F
+    F = FakeSRX()
+    F.install()
 
 
 def teardown_module():
-    conn_patch.stop()
+    F.uninstall()
 
 
-def test_parse_routes():
+def test_parse_no_globals():
     fake_cfg = {
         'firewall': 'fw',
         'ssh_username': 'uu',
         'ssh_password': 'pp',
         'application-map': {'junos-ssh': 'ssh', 'junos-ping': 'ping'},
     }
+    z = F.add_zone('untrust')
+    F.add_address(z, 'host1', '9.0.9.1/32')
+    F.add_address(z, 'host2', '9.0.9.2/32')
+    F.add_address(z, 'puppet', '9.0.9.2/32')
+    F.add_address_set(z, 'hosts', 'host1', 'host2')
+    F.add_interface(z, 'reth0')
+
+    z = F.add_zone('trust')
+    F.add_address(z, 'trustedhost', '10.0.9.2/32')
+    F.add_address(z, 'dmz', '10.1.0.0/16')
+    F.add_address(z, 'shadow', '10.1.99.99/32')
+    F.add_interface(z, 'reth1')
+
+    F.add_policy(('trust', 'trust'),
+                 dict(sequence=1, name='ssh', src='any', dst='any', app='junos-ssh', action='permit'))
+    F.add_policy(('trust', 'trust'),
+                 dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'))
+    F.add_policy(('trust', 'untrust'),
+                 dict(sequence=1, name='ssh', src='any', dst='any', app='junos-ssh', action='permit'))
+    F.add_policy(('trust', 'untrust'),
+                 dict(sequence=2, name='puppet', src='any', dst='puppet', app='puppet', action='permit'))
+    F.add_policy(('trust', 'untrust'),
+                 dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'))
+    F.add_policy(('untrust', 'trust'),
+                 dict(sequence=1, name='no-shadow-ping', src='any', dst='shadow', app='junos-ping', action='deny'))
+    F.add_policy(('untrust', 'trust'),
+                 dict(sequence=2, name='ping', src='any', dst='dmz', app='junos-ping', action='permit'))
+    F.add_policy(('untrust', 'trust'),
+                 dict(sequence=3, name='admin-puppet', src='puppet', dst='trustedhost', app='junos-ssh', action='permit'))
+    F.add_policy(('untrust', 'trust'),
+                 dict(sequence=4, name='admin', src='any-ipv6', dst='trustedhost', app='junos-ssh', action='permit'))
+    F.add_policy(('untrust', 'trust'),
+                 dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'))
+    F.add_policy(('untrust', 'untrust'),
+                 dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'))
+
     rules = scripts.run(fake_cfg, {})
     for r in rules.itervalues():
         r.sort()
@@ -86,9 +79,9 @@ def test_parse_routes():
         ],
         'ssh': [
             Rule(src=IPSet([IP('9.0.9.2')]), dst=IPSet([IP('10.0.9.2')]), app='ssh',
-                 name='admin'),
+                 name='admin-puppet'),
             Rule(src=IPSet([IP('10.0.0.0/8')]), dst=IPSet([IP('0.0.0.0/0')]), app='ssh',
-                 name='ssh--any+ssh-untrust'),
+                 name='ssh'),
         ],
     }
     eq_(rules, exp)

--- a/fwunit/test/integration/test_srx.py
+++ b/fwunit/test/integration/test_srx.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from fwunit.srx import scripts
-from nose.tools import eq_
+from nose.tools import eq_, with_setup
 from fwunit.ip import IP, IPSet
 from fwunit.types import Rule
 from fwunit.test.util.srx_xml import FakeSRX
@@ -11,17 +11,18 @@ from fwunit.test.util.srx_xml import FakeSRX
 F = None
 
 
-def setup_module():
+def install():
     global F
     F = FakeSRX()
     F.install()
 
 
-def teardown_module():
+def uninstall():
     F.uninstall()
 
 
-def test_parse_no_globals():
+@with_setup(install, uninstall)
+def test_run_no_globals():
     fake_cfg = {
         'firewall': 'fw',
         'ssh_username': 'uu',
@@ -82,6 +83,60 @@ def test_parse_no_globals():
                  name='admin-puppet'),
             Rule(src=IPSet([IP('10.0.0.0/8')]), dst=IPSet([IP('0.0.0.0/0')]), app='ssh',
                  name='ssh'),
+        ],
+    }
+    eq_(rules, exp)
+
+
+@with_setup(install, uninstall)
+def test_run_global_policies_and_addrbook():
+    fake_cfg = {
+        'firewall': 'fw',
+        'ssh_username': 'uu',
+        'ssh_password': 'pp',
+        'application-map': {'junos-ssh': 'ssh', 'junos-ping': 'ping'},
+    }
+
+    z = F.add_zone('untrust')
+    F.add_address(z, 'untrust-host', '9.0.9.1/32')
+    F.add_interface(z, 'reth0')
+
+    z = F.add_zone('trust')
+    F.add_address(z, 'trust-host', '10.9.1.1/32')
+    F.add_interface(z, 'reth1')
+
+    ab = F.add_addrbook('global')
+    F.add_address(ab, 'global-host', '10.1.1.1/32')
+
+    ab = F.add_addrbook('public')
+    F.add_address(ab, 'public-host', '2.2.1.1/32')
+    F.add_attach(ab, 'trust')
+    F.add_attach(ab, 'untrust')
+
+    F.add_policy(('trust', 'untrust'),
+                 dict(sequence=1, name='ssh', src='trust-host', dst='untrust-host', app='junos-ssh', action='permit'))
+    F.add_policy(('untrust', 'trust'),
+                 dict(sequence=1, name='puppet', src='public-host', dst='global-host', app='puppet', action='permit'))
+    F.add_policy('global',
+                 dict(sequence=10, name='ping', src='any', dst='any', app='junos-ping', action='permit'))
+    F.add_policy('global',
+                 dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'))
+
+    rules = scripts.run(fake_cfg, {})
+    for r in rules.itervalues():
+        r.sort()
+    exp = {
+        'ping': [
+            Rule(src=IPSet([IP('0.0.0.0/0')]), dst=IPSet([IP('0.0.0.0/0')]),
+                 app='ping', name='ping'),
+        ],
+        'puppet': [
+            Rule(src=IPSet([IP('2.2.1.1')]), dst=IPSet([IP('10.1.1.1')]),
+                 app='puppet', name='puppet'),
+        ],
+        'ssh': [
+            Rule(src=IPSet([IP('10.9.1.1')]), dst=IPSet([IP('9.0.9.1')]),
+                 app='ssh', name='ssh'),
         ],
     }
     eq_(rules, exp)

--- a/fwunit/test/unit/test_srx_parse.py
+++ b/fwunit/test/unit/test_srx_parse.py
@@ -18,20 +18,14 @@ def parse_xml(xml, elt_path=None):
     return elt
 
 
-def test_parse_zones():
+def test_parse_zone():
     f = FakeSRX()
     z = f.add_zone('untrust')
     f.add_address(z, 'host1', '9.0.9.1/32')
     f.add_address(z, 'host2', '9.0.9.2/32')
-    f.add_address(z, 'puppet', '9.0.9.2/32')
+    f.add_address(z, 'puppet', '9.0.9.3/32')
     f.add_address_set(z, 'hosts', 'host1', 'host2')
     f.add_interface(z, 'reth0')
-
-    z = f.add_zone('trust')
-    f.add_address(z, 'trustedhost', '10.0.9.2/32')
-    f.add_address(z, 'dmz', '10.1.0.0/16')
-    f.add_address(z, 'shadow', '10.1.99.99/32')
-    f.add_interface(z, 'reth1')
 
     elt = parse_xml(
         f.fake_show('configuration security zones'), './/security-zone')
@@ -42,6 +36,103 @@ def test_parse_zones():
     eq_(z.addresses['any'], IPSet([IP('0.0.0.0/0')]))
     eq_(z.addresses['any-ipv4'], IPSet([IP('0.0.0.0/0')]))
     eq_(z.addresses['any-ipv6'], IPSet([]))
+    eq_(z.addresses['host1'], IPSet([IP('9.0.9.1')]))
+    eq_(z.addresses['host2'], IPSet([IP('9.0.9.2')]))
+    eq_(z.addresses['puppet'], IPSet([IP('9.0.9.3')]))
+    eq_(z.addresses['hosts'], IPSet([IP('9.0.9.1'), IP('9.0.9.2')]))
+
+
+def test_parse_zone_no_sets():
+    f = FakeSRX()
+    z = f.add_zone('untrust')
+    f.add_address(z, 'trustedhost', '10.0.9.2/32')
+    f.add_address(z, 'dmz', '10.1.0.0/16')
+    f.add_address(z, 'shadow', '10.1.99.99/32')
+    f.add_interface(z, 'reth1')
+
+    elt = parse_xml(
+        f.fake_show('configuration security zones'), './/security-zone')
+    z = parse.Zone._from_xml(elt)
+    eq_(z.interfaces, ['reth1'])
+    eq_(sorted(z.addresses.keys()),
+        sorted(['any', 'any-ipv4', 'any-ipv6', 'trustedhost', 'dmz', 'shadow']))
+    eq_(z.addresses['any'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv4'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv6'], IPSet([]))
+    eq_(z.addresses['trustedhost'], IPSet([IP('10.0.9.2')]))
+    eq_(z.addresses['dmz'], IPSet([IP('10.1.0.0/16')]))
+    eq_(z.addresses['shadow'], IPSet([IP('10.1.99.99')]))
+
+
+def test_parse_global_policy():
+    f = FakeSRX()
+    f.add_policy('global',
+                 dict(sequence=1, name='global-ping', src='any', dst='any',
+                      app='ping', action='permit'))
+    f.add_policy('global',
+                 dict(sequence=10, name='global-deny', src='any', dst='any',
+                      app='any', action='deny'))
+
+    elt = parse_xml(
+        f.fake_show('security policies global'), './/security-context')
+    policies = [parse.Policy._from_xml(None, None, e) for e in elt.findall('./policies/policy-information')]
+    eq_(policies[0].from_zone, None)
+    eq_(policies[0].to_zone, None)
+    eq_(policies[0].to_zone, None)
+    eq_(policies[0].enabled, True)
+    eq_(policies[0].sequence, 1)
+    eq_(policies[0].source_addresses, ['any'])
+    eq_(policies[0].destination_addresses, ['any'])
+    eq_(policies[0].applications, ['ping'])
+    eq_(policies[0].action, 'permit')
+    eq_(policies[0].from_zone, None)
+    eq_(policies[1].to_zone, None)
+    eq_(policies[1].to_zone, None)
+    eq_(policies[1].enabled, True)
+    eq_(policies[1].sequence, 10)
+    eq_(policies[1].source_addresses, ['any'])
+    eq_(policies[1].destination_addresses, ['any'])
+    eq_(policies[1].applications, ['any'])
+    eq_(policies[1].action, 'deny')
+
+
+def test_parse_addrbook_global():
+    f = FakeSRX()
+    ab = f.add_addrbook('global')
+    f.add_address(ab, 'host1', '9.0.9.1/32')
+    f.add_address(ab, 'host2', '9.0.9.2/32')
+    f.add_address_set(ab, 'hosts', 'host1', 'host2')
+
+    elt = parse_xml(
+        f.fake_show('configuration security address-book'), './/address-book')
+    z = parse.AddressBook._from_xml(elt)
+    eq_(z.attaches, [])
+    eq_(sorted(z.addresses.keys()),
+        sorted(['any', 'any-ipv4', 'any-ipv6', 'host1', 'host2', 'hosts']))
+    eq_(z.addresses['any'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv4'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv6'], IPSet([]))
+    eq_(z.addresses['host1'], IPSet([IP('9.0.9.1')]))
+    eq_(z.addresses['host2'], IPSet([IP('9.0.9.2')]))
+    eq_(z.addresses['hosts'], IPSet([IP('9.0.9.1'), IP('9.0.9.2')]))
+
+def test_parse_addrbook_attached():
+    f = FakeSRX()
+    ab = f.add_addrbook('general-stuff')
+    f.add_address(ab, 'trustedhost', '10.0.9.2/32')
+    f.add_attach(ab, 'untrust')
+    f.add_attach(ab, 'trust')
+
+    elt = parse_xml(
+        f.fake_show('configuration security address-book'), './/address-book')
+    z = parse.AddressBook._from_xml(elt)
+    eq_(z.attaches, ['untrust', 'trust'])
+    eq_(sorted(z.addresses.keys()),
+        sorted(['any', 'any-ipv4', 'any-ipv6', 'trustedhost']))
+    eq_(z.addresses['any'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv4'], IPSet([IP('0.0.0.0/0')]))
+    eq_(z.addresses['any-ipv6'], IPSet([]))
+    eq_(z.addresses['trustedhost'], IPSet([IP('10.0.9.2')]))
 
 
 def test_parse_zones_empty():

--- a/fwunit/test/util/srx_xml.py
+++ b/fwunit/test/util/srx_xml.py
@@ -394,15 +394,20 @@ class FakeSRX(object):
             if request == 'security policies global':
                 if 'global' in self.policies:
                     policy_dicts = self.policies['global']
+                    policy_xmls = [policy_tpl % d for d in policy_dicts]
+                    return global_policy_xml % dict(policies='\n'.join(policy_xmls))
                 else:
                     return no_global_policy_xml
             else:
                 request = request.split()
                 from_zone, to_zone = request[3], request[5]
-                policy_dicts = self.policies[from_zone, to_zone]
-            policy_xmls = [policy_tpl % d for d in policy_dicts]
-            return policy_xml % dict(from_zone=from_zone, to_zone=to_zone,
-                                     policies='\n'.join(policy_xmls))
+                try:
+                    policy_dicts = self.policies[from_zone, to_zone]
+                except KeyError:
+                    policy_dicts = []
+                policy_xmls = [policy_tpl % d for d in policy_dicts]
+                return policy_xml % dict(from_zone=from_zone, to_zone=to_zone,
+                                        policies='\n'.join(policy_xmls))
         else:
             raise AssertionError("bad request")
 


### PR DESCRIPTION
The JunOS-SRX line 12.x supports a notion of a global policies and global zones. When they are used on a device that fwunit fetches configuration from, it makes fwunit exit with an error condition. Instead, fwunit should be able to parse what is there and use the information for flow calculations.

In the branch
security {
address-book {
global {

one can have multiple entries that are valid for all zones.

            address corp-ww_5 10.246.24.0/21;
address-set corp-ww {
                address corp-ww_0;


Sometimes there can be also a global zone. For flow to be permitted from zone A to zone B if no policies exist (or they do, but they don't match) between this pair of zones, the global zone is consulted.

Note - this zone is implicit i.e. does not have to be defined anywhere to be used. Should be autodetected like "are there any rules on the global zone?".

security {
policies{

global {

policy dhcp-helpers { content of policy goes here }
