### PR TITLE
fwunit should respect blackholed routes

### DIFF
--- a/fwunit/srx/process.py
+++ b/fwunit/srx/process.py
@@ -40,11 +40,12 @@ def process_interface_ips(routes):
     matched = IPSet()
     interface_ips = {}
     for r in routes:
-        if not r.interface:
-            continue
         destset = IPSet([r.destination])
-        interface_ips[r.interface] = interface_ips.get(
-            r.interface, IPSet()) + (destset - matched)
+        if r.interface and not r.reject:
+            interface_ips[r.interface] = interface_ips.get(
+                r.interface, IPSet()) + (destset - matched)
+        # consider the route matched even if it didn't have an
+        # interface or is a blackhole
         matched = matched + destset
     return interface_ips
 

--- a/fwunit/test/unit/test_srx_parse.py
+++ b/fwunit/test/unit/test_srx_parse.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 from fwunit.ip import IP, IPSet
 from fwunit.srx import parse
 from nose.tools import eq_
+from fwunit.test.util.srx_xml import route_xml_blackhole
 from fwunit.test.util.srx_xml import route_xml_11_4R6
 from fwunit.test.util.srx_xml import zones_empty_xml
 from fwunit.test.util.srx_xml import FakeSRX
@@ -140,6 +141,14 @@ def test_parse_zones_empty():
     z = parse.Zone._from_xml(elt)
     eq_(z.interfaces, [])
     eq_(sorted(z.addresses.keys()), sorted(['any', 'any-ipv6', 'any-ipv4']))
+
+
+def test_parse_route_blackhole():
+    elt = parse_xml(route_xml_blackhole, './/rt')
+    r = parse.Route._from_xml(elt)
+    eq_(r.destination, IP('20.0.0.0/8'))
+    eq_(r.interface, None)
+    eq_(r.is_local, False)
 
 
 def test_parse_route_11_4R6():

--- a/fwunit/test/util/srx_xml.py
+++ b/fwunit/test/util/srx_xml.py
@@ -84,6 +84,37 @@ route_xml = """\
 </rpc-reply>
 """
 
+route_xml_blackhole = """\
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X44/junos">
+    <route-information xmlns="http://xml.juniper.net/junos/12.1X44/junos-routing">
+        <!-- keepalive -->
+        <route-table>
+            <table-name>inet.0</table-name>
+            <destination-count>273</destination-count>
+            <total-route-count>410</total-route-count>
+            <active-route-count>273</active-route-count>
+            <holddown-route-count>0</holddown-route-count>
+            <hidden-route-count>0</hidden-route-count>
+            <rt junos:style="brief">
+                <rt-destination>20.0.0.0/8</rt-destination>
+                <rt-entry>
+                    <active-tag>*</active-tag>
+                    <current-active/>
+                    <last-active/>
+                    <protocol-name>Aggregate</protocol-name>
+                    <preference>130</preference>
+                    <age junos:seconds="33111187">54w5d 05:33:07</age>
+                    <nh-type>Reject</nh-type>
+                </rt-entry>
+            </rt>
+        </route-table>
+    </route-information>
+    <cli>
+        <banner>{primary:node1}</banner>
+    </cli>
+</rpc-reply>
+"""
+
 route_xml_11_4R6 = """\
 <rpc-reply xmlns:junos="http://xml.juniper.net/junos/11.4R6/junos">
     <route-information xmlns="http://xml.juniper.net/junos/11.4R6/junos-routing">


### PR DESCRIPTION
When a given subnet is not defined on the firewall in question fwunit thinks it is part of the 0.0.0.0/0 even when the subnet is blackholed.

Example
10.249.0.0/16 is a subnet for the BER1 site.

10.249.8.0/21 is not defined on the fw1.ber1 yet (but reserved for the future).

dustin@fw1.ops.ber1.mozilla.net> show route 10.249.8.0     
inet.0: 57 destinations, 81 routes (56 active, 0 holddown, 1 hidden)
+ = Active Route, - = Last Active, * = Both
10.249.0.0/16      *[Aggregate/130] 53w6d 04:20:33
                      Reject
{primary:node0}

This is caused by

    aggregate {
        route 10.249.0.0/16;
    }
I.e. firewall declares "all of 10.249.0.0/16 belongs to me". This configuration saves us from routing loops, otherwise packets for not yet defined subnets would follow the default route, be forwarded to POPs and POPs would send them back to fw1.ber which would send them back, etc.

fwunit should check if the subnet is blackholed and if it is, take that as "traffic is denied".