### PR TITLE
sequence of global policies not considered in fwunit/srx/process.py

### DIFF
--- a/fwunit/test/integration/test_srx.py
+++ b/fwunit/test/integration/test_srx.py
@@ -120,7 +120,7 @@ def test_run_global_policies_and_addrbook():
     F.add_policy('global',
                  dict(sequence=10, name='ping', src='any', dst='any', app='junos-ping', action='permit'))
     F.add_policy('global',
-                 dict(sequence=10, name='deny', src='any', dst='any', app='any', action='deny'))
+                 dict(sequence=11, name='deny', src='any', dst='any', app='any', action='deny'))
 
     rules = scripts.run(fake_cfg, {})
     for r in rules.itervalues():


### PR DESCRIPTION
On line 191 of process.py, the zpolicies(zone policies) were sorted by their sequence number. However, on line 189 of process.py, the global_policies(global policies) were not sorted. I think the policies should be sorted after the zone policies and global policies are combined.