### PR TITLE
Adjust the example call for fwunit-query

### DIFF
--- a/docs/querying.rst
+++ b/docs/querying.rst
@@ -7,7 +7,7 @@ For example:
 
 .. code-block:: none
 
-    fwunit-query enterprise permitted 10.10.1.1 192.168.1.1 ssh
+    fwunit-query permitted enterprise 10.10.1.1 192.168.1.1 ssh
     Flow permitted
 
 See the script's ``--help`` for more detail.


### PR DESCRIPTION
Hi,
the example doesn't match the actual implementation. The permitted command has to come first and takes "source" as it's first argument.
Cheers